### PR TITLE
Order markup

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <!-- ❗️❗️❗️ Add partials like so for every page -->
+    <include src="./partials/order.html"></include>
     <include src="./partials/footer.html"></include>
   </body>
 </html>

--- a/src/partials/order.html
+++ b/src/partials/order.html
@@ -1,0 +1,48 @@
+<section class="order" id="order">
+  <div class="container">
+    <h2 class="visually-hidden">Pre-order price</h2>
+    <h3 class="title pre-order-title">
+      Вартість <span class="pre-order-title__crossed">1499 грн.</span>
+    </h3>
+    <div class="pre-order">
+      <p class="pre-order__text">
+        Попереднє замовлення - <span class="pre-order__price">995 грн.</span>
+      </p>
+      <p class="pre-order__delivery">
+        Доставка Новою Поштою в лютому-березні 2023 року.
+      </p>
+    </div>
+    <button type="button" class="btn btn--primary pre-order__btn">
+      Попереднє замовлення
+    </button>
+    <div class="pre-order__link">
+      <a href="">Повідомити про наявність</a>
+    </div>
+    <div class="motivation-block">
+      <p>
+        Проінвестуй у свій розвиток та початок великої особистої трансформації.
+        Приєднуйся до
+        <a href="" class="motivation-block__link">спільноти однодумців</a>, яка
+        спільнокоштом запустить перший тираж у друк. Твій вклад сьогодні
+        дозволить цьому проекту розвиватися у близькому майбутньому.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="order" id="order">
+  <div class="container">
+    <h2 class="visually-hidden">Order price</h2>
+    <h3 class="title order-title">
+      Вартість <span class="order-title__accent">1499 грн.</span>
+    </h3>
+    <div class="order-now">
+      <p class="order-now__delivery">
+        Самовивіз у Львові або доставка Новою Поштою
+      </p>
+    </div>
+    <button type="button" class="btn btn--primary order-now__btn">
+      Попереднє замовлення
+    </button>
+  </div>
+</section>

--- a/src/partials/order.html
+++ b/src/partials/order.html
@@ -42,7 +42,7 @@
         Самовивіз у Львові або доставка Новою Поштою
       </p>
       <button type="button" class="btn btn--primary order-now__btn">
-        Попереднє замовлення
+        Оформити замовлення
       </button>
     </div>
   </div>

--- a/src/partials/order.html
+++ b/src/partials/order.html
@@ -1,48 +1,49 @@
 <section class="order" id="order">
   <div class="container">
-    <h2 class="visually-hidden">Pre-order price</h2>
-    <h3 class="title pre-order-title">
-      Вартість <span class="pre-order-title__crossed">1499 грн.</span>
-    </h3>
     <div class="pre-order">
+      <h2 class="visually-hidden">Pre-order price</h2>
+      <h3 class="title pre-order-title">
+        Вартість <span class="pre-order-title__crossed">1499 грн.</span>
+      </h3>
       <p class="pre-order__text">
         Попереднє замовлення - <span class="pre-order__price">995 грн.</span>
       </p>
       <p class="pre-order__delivery">
         Доставка Новою Поштою в лютому-березні 2023 року.
       </p>
-    </div>
-    <button type="button" class="btn btn--primary pre-order__btn">
-      Попереднє замовлення
-    </button>
-    <div class="pre-order__link">
-      <a href="">Повідомити про наявність</a>
-    </div>
-    <div class="motivation-block">
-      <p>
-        Проінвестуй у свій розвиток та початок великої особистої трансформації.
-        Приєднуйся до
-        <a href="" class="motivation-block__link">спільноти однодумців</a>, яка
-        спільнокоштом запустить перший тираж у друк. Твій вклад сьогодні
-        дозволить цьому проекту розвиватися у близькому майбутньому.
-      </p>
+      <button type="button" class="btn btn--primary pre-order__btn">
+        Попереднє замовлення
+      </button>
+      <div class="pre-order__link">
+        <a href="">Повідомити про наявність</a>
+      </div>
+      <div class="motivation-block">
+        <p class="motivation-block__text">
+          Проінвестуй у свій розвиток та початок великої особистої
+          трансформації. Приєднуйся до
+          <a href="" class="motivation-block__link">спільноти однодумців</a>,
+          яка спільнокоштом запустить перший тираж у друк. <br /><br />
+          Твій вклад сьогодні дозволить цьому проекту розвиватися у близькому
+          майбутньому.
+        </p>
+      </div>
     </div>
   </div>
 </section>
 
 <section class="order" id="order">
   <div class="container">
-    <h2 class="visually-hidden">Order price</h2>
-    <h3 class="title order-title">
-      Вартість <span class="order-title__accent">1499 грн.</span>
-    </h3>
     <div class="order-now">
+      <h2 class="visually-hidden">Order price</h2>
+      <h3 class="title order-title">
+        Вартість <span class="order-title__accent">1499 грн.</span>
+      </h3>
       <p class="order-now__delivery">
         Самовивіз у Львові або доставка Новою Поштою
       </p>
+      <button type="button" class="btn btn--primary order-now__btn">
+        Попереднє замовлення
+      </button>
     </div>
-    <button type="button" class="btn btn--primary order-now__btn">
-      Попереднє замовлення
-    </button>
   </div>
 </section>

--- a/src/sass/layout/_order.scss
+++ b/src/sass/layout/_order.scss
@@ -1,5 +1,9 @@
 .container {
   margin-bottom: 72px;
+  @media screen and (min-width: 1440px) {
+    max-width: 1022px;
+    margin-bottom: 172px;
+  }
 }
 
 .order {
@@ -7,12 +11,14 @@
   font-weight: $regular-text;
   text-align: center;
   letter-spacing: -0.02em;
+  color: $black-color;
 }
 
 .pre-order-title {
   margin-bottom: 16px;
 
-  @media screen and (min-width: 1140px) {
+  @media screen and (min-width: 1440px) {
+    font-size: 32px;
     margin-bottom: 18px;
   }
 
@@ -23,6 +29,10 @@
 
 .order-title {
   margin-bottom: 8px;
+  @media screen and (min-width: 1440px) {
+    font-size: 32px;
+    margin-bottom: 18px;
+  }
 
   &__accent {
     color: $accent-color;
@@ -37,6 +47,12 @@
     font-size: 18px;
     font-weight: $medium-text;
     margin-bottom: 16px;
+
+    @media screen and (min-width: 1440px) {
+      font-size: 24px;
+      line-height: calc(28 / 24);
+      margin-bottom: 14px;
+    }
   }
 
   &__price {
@@ -47,24 +63,41 @@
     display: inline-block;
     margin-bottom: 24px;
     color: $secondary-text-color;
+
+    @media screen and (min-width: 1440px) {
+      margin-bottom: 32px;
+      font-size: 18px;
+      font-weight: $regular-text;
+      line-height: calc(24 / 18);
+    }
   }
 
   &__btn {
     display: block;
     margin: 0 auto;
-    margin-bottom: 10px;
+    margin-bottom: 24px;
   }
 
   &__link {
     font-weight: $medium-text;
-    margin-bottom: 10px;
+    margin-bottom: 24px;
     text-decoration: underline;
-    padding: 14px 0;
+    font-size: 14px;
+
+    @media screen and (min-width: 1440px) {
+      margin-bottom: 50px;
+      font-size: 18px;
+      line-height: calc(28 / 18);
+      font-weight: $medium-text;
+    }
   }
 }
 
 .pre-order__delivery {
   width: 246px;
+  @media screen and (min-width: 1440px) {
+    width: 350px;
+  }
 }
 
 .motivation-block {
@@ -73,8 +106,27 @@
   background-color: $background-color;
   text-align: left;
 
+  @media screen and (min-width: 1440px) {
+    padding: 62px 66px;
+  }
+
   &__link {
     font-weight: $bold-text;
     font-style: normal;
+  }
+
+  &__text {
+    font-size: 14px;
+    @media screen and (min-width: 1440px) {
+      font-size: 24px;
+    }
+  }
+
+  &__text br {
+    display: none;
+    @media screen and (min-width: 1440px) {
+      display: initial;
+      padding-top: 20px;
+    }
   }
 }

--- a/src/sass/layout/_order.scss
+++ b/src/sass/layout/_order.scss
@@ -1,0 +1,80 @@
+.container {
+  margin-bottom: 72px;
+}
+
+.order {
+  font-size: 14px;
+  font-weight: $regular-text;
+  text-align: center;
+  letter-spacing: -0.02em;
+}
+
+.pre-order-title {
+  margin-bottom: 16px;
+
+  @media screen and (min-width: 1140px) {
+    margin-bottom: 18px;
+  }
+
+  &__crossed {
+    text-decoration: line-through;
+  }
+}
+
+.order-title {
+  margin-bottom: 8px;
+
+  &__accent {
+    color: $accent-color;
+  }
+}
+
+.pre-order,
+.order-now {
+  line-height: calc(22 / 18);
+
+  &__text {
+    font-size: 18px;
+    font-weight: $medium-text;
+    margin-bottom: 16px;
+  }
+
+  &__price {
+    color: $alert-color;
+  }
+
+  &__delivery {
+    display: inline-block;
+    margin-bottom: 24px;
+    color: $secondary-text-color;
+  }
+
+  &__btn {
+    display: block;
+    margin: 0 auto;
+    margin-bottom: 10px;
+  }
+
+  &__link {
+    font-weight: $medium-text;
+    margin-bottom: 10px;
+    text-decoration: underline;
+    padding: 14px 0;
+  }
+}
+
+.pre-order__delivery {
+  width: 246px;
+}
+
+.motivation-block {
+  padding: 14px;
+  font-style: italic;
+  background-color: $background-color;
+  text-align: left;
+
+  &__link {
+    font-weight: $bold-text;
+    font-style: normal;
+  }
+}

--- a/src/sass/layout/_order.scss
+++ b/src/sass/layout/_order.scss
@@ -75,7 +75,12 @@
   &__btn {
     display: block;
     margin: 0 auto;
+    padding: 10px 64px;
     margin-bottom: 24px;
+    @media screen and (min-width: 1440px) {
+      margin-bottom: 14px;
+      padding: 14px 32px;
+    }
   }
 
   &__link {


### PR DESCRIPTION
Layout order section for mobile and desktop screens. 
![Screenshot_16](https://user-images.githubusercontent.com/49239848/210236714-22577fd8-a934-4e38-b9c4-2c8087921b2b.png)

important: the 'order' partial includes two options for displaying content, for pre-prder and for order now. Seems it needs to be splited to two different files or so when we will got information about connected backend and admin-page.
